### PR TITLE
fix(main): remove redundant environment indicator from response message

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	r.GET("/send", func(c *gin.Context) {
 		logrus.Infof("Hello, World!")
-		c.JSON(http.StatusOK, gin.H{"message": "Hello, World!, uat"})
+		c.JSON(http.StatusOK, gin.H{"message": "Hello, World!"})
 	})
 
 	r.Run(":8080")


### PR DESCRIPTION
- Remove the ", uat" suffix from the JSON response message
- This change ensures the response is consistent and not tied to a specific environment

## Description

_What problem does this PR solve? Be concise._

## Related Issue

_Closes #123._

## Type of Change

- [ ] Other: ______

## How Has This Been Tested?

_Describe test steps or automated tests you’ve added._

1. Step 1
2. Step 2
3. Verify expected behavior

## Checklist

- [ ] I’ve added necessary tests  
